### PR TITLE
video: 修复bug，在service层添加redis逻辑

### DIFF
--- a/video/infra/dal/init.go
+++ b/video/infra/dal/init.go
@@ -11,6 +11,7 @@ var DB *gorm.DB
 
 // Init DB
 func Init() {
+	conf.InitConfig()
 	var err error
 	DB, err = gorm.Open(mysql.Open(conf.Database.DSN()),
 		&gorm.Config{

--- a/video/infra/dal/orm.go
+++ b/video/infra/dal/orm.go
@@ -101,12 +101,17 @@ func UnLikeVideo(ctx context.Context, userID int64, videoID int64) error {
 	return nil
 }
 
-// MGetLikeVideo 获取用户点赞的视频
-func MGetLikeVideo(ctx context.Context, userID int64) ([]*model.Video, error) {
+// MGetLikeList 通过用户ID获取用户点赞的Favorite[]数组
+func MGetLikeList(ctx context.Context, userID int64) ([]*model.Favorite, error) {
 	var favorites []*model.Favorite
 	if err := DB.WithContext(ctx).Where("user_id = ?", userID).Find(&favorites).Error; err != nil {
 		return nil, err
 	}
+	return favorites, nil
+}
+
+// MGetLikeVideo 通过Favorite[]数组中的视频ID查询得到model.Video信息
+func MGetLikeVideo(ctx context.Context, favorites []*model.Favorite) ([]*model.Video, error) {
 	length := len(favorites)
 	var videos = make([]*model.Video, length)
 	for i, like := range favorites {

--- a/video/infra/dal/orm.go
+++ b/video/infra/dal/orm.go
@@ -101,21 +101,22 @@ func UnLikeVideo(ctx context.Context, userID int64, videoID int64) error {
 	return nil
 }
 
-// MGetLikeList 通过用户ID获取用户点赞的Favorite[]数组
-func MGetLikeList(ctx context.Context, userID int64) ([]*model.Favorite, error) {
+// MGetLikeList 通过用户ID获取用户点赞的视频ID数组
+func MGetLikeList(ctx context.Context, userID int64) ([]int64, error) {
 	var favorites []*model.Favorite
 	if err := DB.WithContext(ctx).Where("user_id = ?", userID).Find(&favorites).Error; err != nil {
 		return nil, err
 	}
-	return favorites, nil
+	var likeList []int64
+	for _, favorite := range favorites {
+		likeList = append(likeList, favorite.VideoId)
+	}
+	return likeList, nil
 }
 
-// MGetLikeVideo 通过Favorite[]数组中的视频ID查询得到model.Video信息
-func MGetLikeVideo(ctx context.Context, favorites []*model.Favorite) ([]*model.Video, error) {
-	length := len(favorites)
-	var videos = make([]*model.Video, length)
-	for i, like := range favorites {
-		DB.WithContext(ctx).Where("ID = ?", like.VideoId).First(&videos[i])
-	}
-	return videos, nil
+// MGetVideoInfo 通过视频ID查询得到model.Video信息
+func MGetVideoInfo(ctx context.Context, videoID int64) (*model.Video, error) {
+	var videoInfo *model.Video
+	DB.WithContext(ctx).Where("ID = ?", videoID).First(&videoInfo)
+	return videoInfo, nil
 }

--- a/video/infra/dal/orm_test.go
+++ b/video/infra/dal/orm_test.go
@@ -99,8 +99,8 @@ func TestMGetVideoByTime(t *testing.T) {
 
 func TestLikeVideo(t *testing.T) {
 	testInit()
-	userId := int64(1)
-	videoId := int64(11)
+	userId := int64(3)
+	videoId := int64(14)
 	if err := LikeVideo(context.Background(), userId, videoId); err != nil {
 		panic(err)
 	}
@@ -118,11 +118,9 @@ func TestUnLikeVideo(t *testing.T) {
 func TestMGetLikeList(t *testing.T) {
 	testInit()
 	userId := int64(1)
-	favorites, err := MGetLikeList(context.Background(), userId)
+	likeList, err := MGetLikeList(context.Background(), userId)
 	if err != nil {
 		panic(err)
 	}
-	for i := 0; i < len(favorites); i++ {
-		fmt.Printf("%#v\n", *favorites[i])
-	}
+	fmt.Println(likeList)
 }

--- a/video/infra/dal/orm_test.go
+++ b/video/infra/dal/orm_test.go
@@ -28,21 +28,13 @@ func testInit() {
 	DB = DB.Debug()
 }
 
-/*
 func TestCreateVideo(t *testing.T) {
 	testInit()
-	video := &model.Video{
-		UserId:   6,
-		Title:    "标题",
-		PlayUrl:  "123",
-		CoverUrl: "456",
-	}
-	err := CreateVideo(context.Background(), video)
+	err := CreateVideo(context.Background(), 3, "3_title", "3_playUrl", "3_coverUrl")
 	if err != nil {
 		panic(err)
 	}
 }
-*/
 
 func TestMGetVideoByUserId(t *testing.T) {
 	testInit()
@@ -119,14 +111,14 @@ func TestUnLikeVideo(t *testing.T) {
 	}
 }
 
-func TestMGetLikeVideo(t *testing.T) {
+func TestMGetLikeList(t *testing.T) {
 	testInit()
 	userId := int64(1)
-	videos, err := MGetLikeVideo(context.Background(), userId)
+	favorites, err := MGetLikeList(context.Background(), userId)
 	if err != nil {
 		panic(err)
 	}
-	for i := 0; i < len(videos); i++ {
-		fmt.Printf("%#v\n", *videos[i])
+	for i := 0; i < len(favorites); i++ {
+		fmt.Printf("%#v\n", *favorites[i])
 	}
 }

--- a/video/infra/dal/orm_test.go
+++ b/video/infra/dal/orm_test.go
@@ -30,7 +30,11 @@ func testInit() {
 
 func TestCreateVideo(t *testing.T) {
 	testInit()
-	err := CreateVideo(context.Background(), 3, "3_title", "3_playUrl", "3_coverUrl")
+	userID := int64(3)
+	title := "3_title"
+	playUrl := "3_playUrl"
+	coverUrl := "3_coverUrl"
+	err := CreateVideo(context.Background(), userID, title, playUrl, coverUrl)
 	if err != nil {
 		panic(err)
 	}

--- a/video/infra/redis/get.go
+++ b/video/infra/redis/get.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 )
 
-func GetPublishList(userId int64) (*[]model.Video, error) {
+func GetPublishList(userId int64) ([]*model.Video, error) {
 	redisConn := redisPool.Get()
 	defer redisConn.Close()
 
@@ -30,7 +30,7 @@ func GetPublishList(userId int64) (*[]model.Video, error) {
 		return nil, err
 	}
 	videoRedisList := *videoRedisListp
-	videoList := make([]model.Video, len(videoRedisList))
+	videoList := make([]*model.Video, len(videoRedisList))
 
 	for i := range videoRedisList {
 		videoId := videoRedisList[i].VideoId
@@ -54,7 +54,7 @@ func GetPublishList(userId int64) (*[]model.Video, error) {
 			return nil, err
 		}
 
-		videoList[i] = model.Video{
+		videoList[i] = &model.Video{
 			UserId:        videoRedisList[i].UserId,
 			Title:         videoRedisList[i].Title,
 			PlayUrl:       videoRedisList[i].PlayUrl,
@@ -64,7 +64,7 @@ func GetPublishList(userId int64) (*[]model.Video, error) {
 		}
 		videoList[i].ID = videoId
 	}
-	return &videoList, nil
+	return videoList, nil
 }
 
 func GetVideoInfo(videoId int64) (*model.Video, error) {

--- a/video/infra/redis/redis_test.go
+++ b/video/infra/redis/redis_test.go
@@ -80,3 +80,21 @@ func TestDelPublishList(t *testing.T) {
 		fmt.Println(err)
 	}
 }
+
+func TestAddLikeList(t *testing.T) {
+	testInit()
+	var likeList = []int64{11, 20}
+	err := AddLikeList(1, likeList)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func TestGetLikeList(t *testing.T) {
+	testInit()
+	likeList, err := GetLikeList(3)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(likeList)
+}

--- a/video/infra/redis/redis_test.go
+++ b/video/infra/redis/redis_test.go
@@ -98,3 +98,12 @@ func TestGetLikeList(t *testing.T) {
 	}
 	fmt.Println(likeList)
 }
+
+func TestGetIsLikeById(t *testing.T) {
+	testInit()
+	isLikeById, err := GetIsLikeById(2, 13)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(isLikeById)
+}

--- a/video/infra/redis/redis_test.go
+++ b/video/infra/redis/redis_test.go
@@ -69,8 +69,8 @@ func TestGetPublishList(t *testing.T) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	videoList := *result
-	fmt.Println(videoList)
+	videoList := result
+	fmt.Printf("%v\n", videoList)
 }
 
 func TestDelPublishList(t *testing.T) {

--- a/video/infra/redis/redis_test.go
+++ b/video/infra/redis/redis_test.go
@@ -72,3 +72,11 @@ func TestGetPublishList(t *testing.T) {
 	videoList := *result
 	fmt.Println(videoList)
 }
+
+func TestDelPublishList(t *testing.T) {
+	testInit()
+	err := DelPublishList(5)
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/video/infra/redis/set.go
+++ b/video/infra/redis/set.go
@@ -69,7 +69,7 @@ func AddLikeList(userId int64, likeList []int64) error {
 	redisConn := redisPool.Get()
 	defer redisConn.Close()
 
-	key := constant.FollowRedisPrefix + strconv.FormatInt(userId, 10)
+	key := constant.LikeRedisPrefix + strconv.FormatInt(userId, 10)
 
 	l := len(likeList)
 

--- a/video/service/feed.go
+++ b/video/service/feed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
 	"douyin/video/infra/dal"
+	"douyin/video/infra/redis"
 	"douyin/video/pack"
 	"time"
 )
@@ -24,12 +25,25 @@ func (s *MGetVideoByTimeService) MGetVideoByTime(req *videoproto.GetVideoListByT
 		return nil, 0, err
 	}
 	videos := pack.Videos(videoModels) // 类型转换：视频id、base_info、点赞数、评论数已经得到，还需要判断是否点赞
-	appUserID := req.AppUserId
 	// 把视频的其他信息进行绑定
+	appUserID := req.AppUserId
+	isLikeKeyExist, err := redis.IsLikeKeyExist(appUserID)
+	if err != nil {
+		return nil, 0, err
+	}
+	if isLikeKeyExist == false {
+		// 如果redis没有appUserID的记录，则去mysql查询一次点赞列表进行缓存
+		likeList, err := dal.MGetLikeList(s.ctx, appUserID)
+		if err != nil {
+			return nil, 0, err
+		}
+		if err := redis.AddLikeList(appUserID, likeList); err != nil {
+			return nil, 0, err
+		}
+	}
 	for i := 0; i < len(videos); i++ {
-		vid := videos[i].VideoId
 		if appUserID > 0 { // 判断是否进行了登陆
-			isFavorite, err := dal.IsFavorite(s.ctx, vid, appUserID)
+			isFavorite, err := redis.GetIsLikeById(appUserID, videos[i].VideoId)
 			if err != nil {
 				return nil, 0, err
 			}

--- a/video/service/get_like_video_list.go
+++ b/video/service/get_like_video_list.go
@@ -17,12 +17,15 @@ func NewMGetLikeVideoService(ctx context.Context) *MGetLikeVideoService {
 
 // MGetLikeVideo 通过用户ID从DAO层获取喜欢视频的基本信息，并查出当前用户是否点赞，组装后返回
 func (s *MGetLikeVideoService) MGetLikeVideo(req *videoproto.GetLikeVideoListReq) ([]*videoproto.VideoInfo, error) {
-	videoModels, err := dal.MGetLikeVideo(s.ctx, req.AppUserId)
-	// 只能得到视频id，uid,title,play_url,cover_url,created_time
+	favorites, err := dal.MGetLikeList(s.ctx, req.AppUserId)
 	if err != nil {
 		return nil, err
 	}
-	//fmt.Println(videoModels)
+	// 只能得到视频id，uid,title,play_url,cover_url,created_time
+	videoModels, err := dal.MGetLikeVideo(s.ctx, favorites)
+	if err != nil {
+		return nil, err
+	}
 	videos := pack.Videos(videoModels) // 做类型转换：视频id、base_info、点赞数、评论数已经得到，还需要判断是否点赞
 	// 把视频的其他信息进行绑定
 	for i := 0; i < len(videos); i++ {

--- a/video/service/get_like_video_list.go
+++ b/video/service/get_like_video_list.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
 	"douyin/video/infra/dal"
+	"douyin/video/infra/dal/model"
+	"douyin/video/infra/redis"
 	"douyin/video/pack"
 )
 
@@ -17,14 +19,35 @@ func NewMGetLikeVideoService(ctx context.Context) *MGetLikeVideoService {
 
 // MGetLikeVideo 通过用户ID从DAO层获取喜欢视频的基本信息，并查出当前用户是否点赞，组装后返回
 func (s *MGetLikeVideoService) MGetLikeVideo(req *videoproto.GetLikeVideoListReq) ([]*videoproto.VideoInfo, error) {
-	favorites, err := dal.MGetLikeList(s.ctx, req.AppUserId)
+	userID := req.AppUserId
+	var likeList []int64
+	likeList, err := redis.GetLikeList(userID)
 	if err != nil {
 		return nil, err
 	}
-	// 只能得到视频id，uid,title,play_url,cover_url,created_time
-	videoModels, err := dal.MGetLikeVideo(s.ctx, favorites)
-	if err != nil {
-		return nil, err
+	if len(likeList) == 0 {
+		// 缓存未命中，去数据库查询，然后缓存到redis
+		likeList, err = dal.MGetLikeList(s.ctx, userID)
+		if err != nil {
+			return nil, err
+		}
+		if err := redis.AddLikeList(userID, likeList); err != nil {
+			return nil, err
+		}
+	}
+	var videoModels = make([]*model.Video, len(likeList))
+	for i, videoID := range likeList {
+		videoModels[i], err = redis.GetVideoInfo(videoID)
+		if err != nil {
+			// 缓存未命中，去数据库查询，然后缓存到redis
+			videoModels[i], err = dal.MGetVideoInfo(s.ctx, videoID)
+			if err != nil {
+				return nil, err
+			}
+			if err := redis.AddVideoInfo(*videoModels[i]); err != nil {
+				return nil, err
+			}
+		}
 	}
 	videos := pack.Videos(videoModels) // 做类型转换：视频id、base_info、点赞数、评论数已经得到，还需要判断是否点赞
 	// 把视频的其他信息进行绑定

--- a/video/service/get_like_video_list.go
+++ b/video/service/get_like_video_list.go
@@ -21,11 +21,13 @@ func NewMGetLikeVideoService(ctx context.Context) *MGetLikeVideoService {
 func (s *MGetLikeVideoService) MGetLikeVideo(req *videoproto.GetLikeVideoListReq) ([]*videoproto.VideoInfo, error) {
 	userID := req.AppUserId
 	var likeList []int64
-	likeList, err := redis.GetLikeList(userID)
+	isLikeKeyExist, err := redis.IsLikeKeyExist(userID)
 	if err != nil {
 		return nil, err
 	}
-	if len(likeList) == 0 {
+	if isLikeKeyExist == true {
+		likeList, err = redis.GetLikeList(userID)
+	} else {
 		// 缓存未命中，去数据库查询，然后缓存到redis
 		likeList, err = dal.MGetLikeList(s.ctx, userID)
 		if err != nil {

--- a/video/service/get_publish_list.go
+++ b/video/service/get_publish_list.go
@@ -36,9 +36,22 @@ func (s *MGetVideoByUserIdService) MGetVideo(req *videoproto.GetVideoListByUserI
 	videos := pack.Videos(videoModels) // 做类型转换：视频id、base_info、点赞数、评论数已经得到，还需要判断是否点赞
 	// 把视频的其他信息进行绑定
 	appUserID := req.AppUserId
+	isLikeKeyExist, err := redis.IsLikeKeyExist(appUserID)
+	if err != nil {
+		return nil, err
+	}
+	if isLikeKeyExist == false {
+		// 如果redis没有appUserID的记录，则去mysql查询一次点赞列表进行缓存
+		likeList, err := dal.MGetLikeList(s.ctx, appUserID)
+		if err != nil {
+			return nil, err
+		}
+		if err := redis.AddLikeList(appUserID, likeList); err != nil {
+			return nil, err
+		}
+	}
 	for i := 0; i < len(videos); i++ {
-		vid := videos[i].VideoId
-		isFavorite, err := dal.IsFavorite(s.ctx, vid, appUserID)
+		isFavorite, err := redis.GetIsLikeById(appUserID, videos[i].VideoId)
 		if err != nil {
 			return nil, err
 		}

--- a/video/service/get_publish_list.go
+++ b/video/service/get_publish_list.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
 	"douyin/video/infra/dal"
+	"douyin/video/infra/dal/model"
+	"douyin/video/infra/redis"
 	"douyin/video/pack"
 )
 
@@ -17,10 +19,19 @@ func NewMGetVideoByUserIdService(ctx context.Context) *MGetVideoByUserIdService 
 
 // MGetVideo 通过UserID从DAO层获取视频基本信息，并查出当前用户是否点赞，组装后返回
 func (s *MGetVideoByUserIdService) MGetVideo(req *videoproto.GetVideoListByUserIdReq) ([]*videoproto.VideoInfo, error) {
-	videoModels, err := dal.MGetVideoByUserID(s.ctx, req.UserId)
+	userID := req.UserId
 	// 只能得到视频id,uid,title，play_url,cover_url,created_time
+	var videoModels []*model.Video
+	videoModels, err := redis.GetPublishList(userID)
 	if err != nil {
-		return nil, err
+		// 缓存未命中，去数据库查询，然后缓存到redis
+		videoModels, err = dal.MGetVideoByUserID(s.ctx, userID)
+		if err != nil {
+			return nil, err
+		}
+		if err := redis.AddPublishList(videoModels, userID); err != nil {
+			return nil, err
+		}
 	}
 	videos := pack.Videos(videoModels) // 做类型转换：视频id、base_info、点赞数、评论数已经得到，还需要判断是否点赞
 	// 把视频的其他信息进行绑定

--- a/video/service/like_video.go
+++ b/video/service/like_video.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
 	"douyin/video/infra/dal"
+	"douyin/video/infra/redis"
 )
 
 type LikeVideoService struct {
@@ -15,6 +16,29 @@ func NewLikeVideoService(ctx context.Context) *LikeVideoService {
 }
 
 func (s *LikeVideoService) LikeVideo(req *videoproto.LikeVideoReq) error {
-	// 如果插入错误，返回error
-	return dal.LikeVideo(s.ctx, req.UserId, req.VideoId)
+	userID := req.UserId
+	videoID := req.VideoId
+	if err := dal.LikeVideo(s.ctx, userID, videoID); err != nil {
+		return err
+	}
+	isLikeKeyExist, err := redis.IsLikeKeyExist(userID)
+	if err != nil {
+		return err
+	}
+	if isLikeKeyExist == true {
+		// 如果redis有这个userID的记录，则需要在redis中再加入这条新的点赞的操作，确保和mysql一致
+		if err := redis.AddLike(userID, videoID); err != nil {
+			return err
+		}
+	} else {
+		// 如果redis没有这个userID的记录，则去mysql查询一次点赞列表进行缓存
+		likeList, err := dal.MGetLikeList(s.ctx, userID)
+		if err != nil {
+			return err
+		}
+		if err := redis.AddLikeList(userID, likeList); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/video/service/publish_video.go
+++ b/video/service/publish_video.go
@@ -18,6 +18,7 @@ func NewCreateVideoService(ctx context.Context) *CreateVideoService {
 func (s *CreateVideoService) CreateVideo(req *videoproto.CreateVideoReq) error {
 	// 投稿的时候，直接删除缓存里面的pulish:id
 	// 因为redis和数据库不一致，方便起见直接删除，下次获取投稿列表的时候再缓存
+	// 因为投稿是个低频操作，所以可以这样处理；点赞则不同
 	if err := redis.DelPublishList(req.VideoBaseInfo.UserId); err != nil {
 		return err
 	}

--- a/video/service/publish_video.go
+++ b/video/service/publish_video.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
 	"douyin/video/infra/dal"
+	"douyin/video/infra/redis"
 )
 
 type CreateVideoService struct {
@@ -15,6 +16,11 @@ func NewCreateVideoService(ctx context.Context) *CreateVideoService {
 }
 
 func (s *CreateVideoService) CreateVideo(req *videoproto.CreateVideoReq) error {
+	// 投稿的时候，直接删除缓存里面的pulish:id
+	// 因为redis和数据库不一致，方便起见直接删除，下次获取投稿列表的时候再缓存
+	if err := redis.DelPublishList(req.VideoBaseInfo.UserId); err != nil {
+		return err
+	}
 	// 如果添加失败，返回error
 	return dal.CreateVideo(s.ctx, req.VideoBaseInfo.UserId, req.VideoBaseInfo.Title, req.VideoBaseInfo.PlayUrl, req.VideoBaseInfo.CoverUrl)
 }

--- a/video/service/publish_video_test.go
+++ b/video/service/publish_video_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"context"
+	"douyin/code_gen/kitex_gen/videoproto"
+	"douyin/video/infra/dal"
+	"douyin/video/infra/redis"
+	"testing"
+)
+
+func testInit() {
+	dal.Init()
+	redis.Init()
+}
+
+func TestCreateVideo(t *testing.T) {
+	testInit()
+	req := &videoproto.CreateVideoReq{
+		VideoBaseInfo: &videoproto.VideoBaseInfo{
+			UserId:   int64(5),
+			PlayUrl:  "testPlayUrl",
+			CoverUrl: "testCoverUrl",
+			Title:    "testTitle",
+		},
+	}
+	err := NewCreateVideoService(context.Background()).CreateVideo(req)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/video/service/test/get_like_video_list_test.go
+++ b/video/service/test/get_like_video_list_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"context"
+	"douyin/code_gen/kitex_gen/videoproto"
+	"douyin/video/service"
+	"fmt"
+	"testing"
+)
+
+func TestMGetLikeVideo(t *testing.T) {
+	testInit()
+	req := &videoproto.GetLikeVideoListReq{
+		AppUserId: int64(19),
+	}
+	videoInfos, err := service.NewMGetLikeVideoService(context.Background()).MGetLikeVideo(req)
+	fmt.Printf("%v\n", videoInfos)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/video/service/test/get_publish_list_test.go
+++ b/video/service/test/get_publish_list_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"context"
+	"douyin/code_gen/kitex_gen/videoproto"
+	"douyin/video/service"
+	"fmt"
+	"testing"
+)
+
+func TestMGetVideo(t *testing.T) {
+	testInit()
+	req := &videoproto.GetVideoListByUserIdReq{
+		UserId: int64(5),
+	}
+	videoInfos, err := service.NewMGetVideoByUserIdService(context.Background()).MGetVideo(req)
+	fmt.Printf("%v\n", videoInfos)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/video/service/test/init.go
+++ b/video/service/test/init.go
@@ -1,0 +1,11 @@
+package test
+
+import (
+	"douyin/video/infra/dal"
+	"douyin/video/infra/redis"
+)
+
+func testInit() {
+	dal.Init()
+	redis.Init()
+}

--- a/video/service/test/publish_video_test.go
+++ b/video/service/test/publish_video_test.go
@@ -1,17 +1,11 @@
-package service
+package test
 
 import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
-	"douyin/video/infra/dal"
-	"douyin/video/infra/redis"
+	"douyin/video/service"
 	"testing"
 )
-
-func testInit() {
-	dal.Init()
-	redis.Init()
-}
 
 func TestCreateVideo(t *testing.T) {
 	testInit()
@@ -23,7 +17,7 @@ func TestCreateVideo(t *testing.T) {
 			Title:    "testTitle",
 		},
 	}
-	err := NewCreateVideoService(context.Background()).CreateVideo(req)
+	err := service.NewCreateVideoService(context.Background()).CreateVideo(req)
 	if err != nil {
 		panic(err)
 	}

--- a/video/service/unlike_video.go
+++ b/video/service/unlike_video.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"douyin/code_gen/kitex_gen/videoproto"
 	"douyin/video/infra/dal"
+	"douyin/video/infra/redis"
 )
 
 type UnLikeVideoService struct {
@@ -15,6 +16,29 @@ func NewUnLikeVideoService(ctx context.Context) *UnLikeVideoService {
 }
 
 func (s *UnLikeVideoService) UnLikeVideo(req *videoproto.UnLikeVideoReq) error {
-	// 如果删除错误，返回error
-	return dal.UnLikeVideo(s.ctx, req.UserId, req.VideoId)
+	userID := req.UserId
+	videoID := req.VideoId
+	if err := dal.UnLikeVideo(s.ctx, userID, videoID); err != nil {
+		return err
+	}
+	isLikeKeyExist, err := redis.IsLikeKeyExist(userID)
+	if err != nil {
+		return err
+	}
+	if isLikeKeyExist == true {
+		// 如果redis有这个userID的记录，则需要在redis中删去这条like记录，确保和mysql一致
+		if err := redis.DeleteLike(userID, videoID); err != nil {
+			return err
+		}
+	} else {
+		// 如果redis没有这个userID的记录，则去mysql查询一次点赞列表进行缓存
+		likeList, err := dal.MGetLikeList(s.ctx, userID)
+		if err != nil {
+			return err
+		}
+		if err := redis.AddLikeList(userID, likeList); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
1. 拆分dal层的MGetLikeVideo为两个方法MGetLikeList和MGetLikeVideo，便于在service层添加redis逻辑；修改了orm_test的对应方法
2. 修复了orm_test中CreateVideo的bug；修复了数据库初始化的bug；**添加了publish_video的redis逻辑**，并增加了对应的test；添加了部分redis_test
3. 修改redis中GetPublishList()的返回类型；**添加get_publish_list的redis逻辑**；重构video服务的测试代码结构
4. **添加get_like_video_list的redis逻辑**；修复redis中AddLikeList()方法的bug